### PR TITLE
feat: add optional "is sortable" icons

### DIFF
--- a/src/components/NveTable/NveTable.vue
+++ b/src/components/NveTable/NveTable.vue
@@ -36,6 +36,7 @@ const props = withDefaults(defineProps<PropsType>(), {
   itemId: (_, index: number) => index,
   hideAllFilters: false,
   stickyFirstColumn: false,
+  hideSortableIcon: true,
 });
 
 const localPageSize = ref(props.pageSize);
@@ -372,7 +373,9 @@ const clickRow = (row: T, event: MouseEvent) => {
                 />
               </template>
               <template v-else>
-                <span style="width: 24px; display: inline-block"></span>
+                <span style="width: 24px; display: inline-block">
+                  <nve-icon v-if="!hideSortableIcon" name="swap_vert" />
+                </span>
               </template>
             </button>
             <template v-else-if="$slots[`header.${header.key}`]">

--- a/src/components/NveTable/table.types.ts
+++ b/src/components/NveTable/table.types.ts
@@ -42,6 +42,7 @@ export type TableProps<T> = {
   hideHeader?: boolean;
   hideTableHeader?: boolean;
   hideEmpty?: boolean;
+  hideSortableIcon?: boolean;
   tableclass?: string;
   tableholderclass?: string;
   stickyHeader?: boolean;


### PR DESCRIPTION
Vi har fått en tilbakemelding om at sluttbruker ønsker muligheten å se hvilke kolonner som er sorterbare, ikke bare ved hover. Legger på et flagg: "hideSortableIcon" - by default true. 

"Sorterbar"-ikonet ser slik ut:
<img width="255" height="242" alt="image" src="https://github.com/user-attachments/assets/99d38a11-7b42-417c-8b71-4eb335a57f56" />

Gjerne kom med innspill :)